### PR TITLE
[Fix] 카카오 맵 SDK 클래스명 충돌 문제 해결 - #19

### DIFF
--- a/src/components/KakaoMap.tsx
+++ b/src/components/KakaoMap.tsx
@@ -5,7 +5,7 @@ import LoadingSpinner from './LoadingSpinner';
 const KakaoMap: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const mapRef = useRef<kakao.maps.KakaoMap | null>(null);
+  const mapRef = useRef<kakao.maps.Map | null>(null);
   const userMarkerRef = useRef<kakao.maps.Marker | null>(null);
 
   useEffect(() => {

--- a/src/utils/kakaoMap.ts
+++ b/src/utils/kakaoMap.ts
@@ -33,7 +33,7 @@ export const loadKakaoMapSDK = (): Promise<void> => {
 
 
 // 지도 생성
-export const createMap = (coords: Coords): kakao.maps.KakaoMap => {
+export const createMap = (coords: Coords): kakao.maps.Map => {
   const container = document.getElementById('map');
   if (!container) {
     throw new Error('지도를 표시할 컨테이너를 찾을 수 없습니다.');
@@ -44,14 +44,14 @@ export const createMap = (coords: Coords): kakao.maps.KakaoMap => {
     level: 4,
   };
   
-  const mapInstance = new window.kakao.maps.KakaoMap(container, options);
+  const mapInstance = new window.kakao.maps.Map(container, options);
   
   return mapInstance;
 };
 
 // 위치 권한 요청 및 실시간 위치 감시
 export const initGeolocation = (
-  map: kakao.maps.KakaoMap,
+  map: kakao.maps.Map,
   onLocationUpdate: (marker: kakao.maps.Marker) => void,
   onLoadingChange: (loading: boolean) => void,
   onError: (error: GeolocationPositionError) => void

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -21,7 +21,7 @@ declare global {
     kakao: {
       maps: {
         load: (callback: () => void) => void;
-        KakaoMap: new (container: HTMLElement, options: kakao.maps.MapOptions) => kakao.maps.KakaoMap;
+        Map: new (container: HTMLElement, options: kakao.maps.MapOptions) => kakao.maps.Map;
         LatLng: new (lat: number, lng: number) => kakao.maps.LatLng;
         Marker: new (options: kakao.maps.MarkerOptions) => kakao.maps.Marker;
         MapOptions: {
@@ -29,7 +29,7 @@ declare global {
           level: number;
         };
         MarkerOptions: {
-          map: kakao.maps.KakaoMap;
+          map: kakao.maps.Map;
           position: kakao.maps.LatLng;
         };
       };
@@ -38,7 +38,7 @@ declare global {
   
   namespace kakao {
     namespace maps {
-      class KakaoMap {
+      class Map {
         constructor(container: HTMLElement, options: MapOptions);
         setCenter(latLng: LatLng): void;
       }
@@ -52,7 +52,7 @@ declare global {
       class Marker {
         constructor(options: MarkerOptions);
         setPosition(latLng: LatLng): void;
-        setMap(map: KakaoMap | null): void;
+        setMap(map: Map | null): void;
       }
       
       interface MapOptions {
@@ -61,7 +61,7 @@ declare global {
       }
       
       interface MarkerOptions {
-        map: KakaoMap;
+        map: Map;
         position: LatLng;
       }
     }


### PR DESCRIPTION
## 📝 관련 이슈
Fixes #19 (카카오 맵 렌더링 오류)

## 문제 상황
- 카카오 맵 컴포넌트에서 다음과 같은 TypeError가 발생했습니다:
```
TypeError: window.kakao.maps.KakaoMap is not a constructor
```
이는 타입 정의에서 `KakaoMap` 클래스를 사용했지만, 실제 카카오 맵 SDK에서는 `Map` 클래스를 사용하기 때문이었습니다.

## 🔧 해결 방법
### 1. 타입 정의 수정 (`src/vite-env.d.ts`)
- `KakaoMap` 클래스를 `Map` 클래스로 변경
- `window.kakao.maps` 인터페이스에서 `Map` 생성자 정의 추가
- `MarkerOptions` 인터페이스의 `map` 속성 타입을 `Map`으로 변경
- `Marker` 클래스의 `setMap` 메서드 매개변수 타입 수정

### 2. 유틸리티 함수 수정 (`src/utils/kakaoMap.ts`)
- `createMap` 함수의 반환 타입을 `kakao.maps.Map`으로 변경
- `initGeolocation` 함수의 매개변수 타입을 `kakao.maps.Map`으로 변경
- 실제 SDK 호출에서 `window.kakao.maps.Map` 사용

### 3. 컴포넌트 타입 수정 (`src/components/KakaoMap.tsx`)
- `mapRef`의 타입을 `kakao.maps.Map`으로 변경

## ✅ 개선 효과
- 오류 해결: 카카오 맵이 정상적으로 렌더링됨
- 타입 안정성: 모든 타입 참조가 실제 SDK 구조와 일치
- 충돌 방지: 네임스페이스(kakao.maps.Map)를 사용하여 JavaScript 내장 Map과의 충돌 방지
- 코드 일관성: 전체 코드베이스에서 일관된 타입 사용

## 테스트
- [x] 카카오 맵 컴포넌트 정상 렌더링 확인
- [x] 지도 초기화 및 마커 표시 확인
- [x] 위치 권한 요청 및 실시간 위치 업데이트 확인
- [x] TypeScript 컴파일 오류 없음 확인

### 변경된 파일:
- `src/vite-env.d.ts`
- `src/utils/kakaoMap.ts`
- `src/components/KakaoMap.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Kakao 지도 관련 타입 명칭을 기존의 KakaoMap에서 Map으로 일관되게 변경하였습니다.  
  * 지도 생성 및 위치 초기화 함수의 타입 정의가 최신 Kakao Maps JavaScript API 명칭과 맞춰졌습니다.  
  * 타입 선언 파일에서도 관련 클래스 및 타입 이름이 통일되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->