### PR TITLE
[Feature] 산책로 API 연동 및 경로 시각화 구현 - #56

### DIFF
--- a/LLM_도움요청_프롬프트.md
+++ b/LLM_도움요청_프롬프트.md
@@ -1,0 +1,108 @@
+# 카카오맵 마커/폴리라인 제거 문제 해결 도움 요청
+
+## 🎯 당신의 역할
+당신은 **React + 카카오맵 API 전문가**입니다. 아래 문제에 대한 **구체적이고 실행 가능한 해결책**을 제시해주세요.
+
+## 📋 문제 상황
+
+React TypeScript 환경에서 카카오맵 API로 생성한 **마커와 폴리라인이 `setMap(null)` 호출 후에도 화면에서 사라지지 않습니다**.
+
+### 기술 스택
+- React 18 + TypeScript + Vite
+- 카카오맵 JavaScript API
+- useState hooks로 상태 관리
+
+### 문제 코드
+```typescript
+// 마커 생성
+const marker = new window.kakao.maps.Marker({
+  position: latLng,
+  map: map.current,
+});
+setTrailMarker(marker);
+
+// CustomOverlay 생성 (문제의 핵심)
+const startLabel = document.createElement('div');
+startLabel.textContent = '시작';
+const startOverlay = new window.kakao.maps.CustomOverlay({
+  position: latLng,
+  content: startLabel,
+  map: map.current,
+});
+
+// 제거 시도 (실패)
+marker.setMap(null);
+startOverlay.setMap(null);
+// 🚫 여전히 화면에 보임
+```
+
+### 시도한 방법들 (모두 실패)
+1. `setVisible(false)` + `setMap(null)`
+2. `map.relayout()` 호출
+3. DOM 직접 조작
+4. React state 초기화
+
+## 🔍 핵심 질문
+
+1. **카카오맵 CustomOverlay의 올바른 제거 방법은?**
+2. **React 환경에서 카카오맵 객체 라이프사이클 관리 베스트 프랙티스는?**
+3. **DOM 조작 없이 순수 API만으로 해결 가능한가?**
+
+## 💡 요구사항
+
+다음 중 **가장 효과적인 방법** 또는 **새로운 해결책**을 제시해주세요:
+
+### 옵션 A: 지도 재초기화
+```typescript
+// 지도 인스턴스를 완전히 새로 생성
+const reinitializeMap = () => {
+  map.current = null;
+  // 새 인스턴스 생성
+};
+```
+
+### 옵션 B: 마커 관리 패턴 개선
+```typescript
+// 마커들을 배열로 관리하고 일괄 제거
+const markers = useRef([]);
+const clearAllMarkers = () => {
+  markers.current.forEach(marker => marker.setMap(null));
+  markers.current = [];
+};
+```
+
+### 옵션 C: CustomOverlay 대안
+```typescript
+// InfoWindow나 다른 API 사용
+const infoWindow = new kakao.maps.InfoWindow({
+  content: '<div>시작</div>'
+});
+```
+
+## 🎯 원하는 답변 형태
+
+```typescript
+// ✅ 실제 작동하는 코드 예시
+const handleRemoveMarkers = () => {
+  // 구체적인 구현
+};
+
+// 💡 왜 이 방법이 효과적인지 설명
+// 🚫 피해야 할 안티패턴들
+```
+
+## 📝 추가 정보 필요시
+
+다음 정보를 요청하시면 즉시 제공 가능합니다:
+- 전체 컴포넌트 코드
+- 브라우저 개발자 도구 DOM 구조
+- 에러 로그 및 네트워크 상태
+- 카카오맵 SDK 버전 정보
+
+---
+
+**🙏 부탁**: 이론보다는 **즉시 적용 가능한 실용적인 해결책**을 우선적으로 제시해주세요. 카카오맵 API의 숨겨진 메서드나 고급 패턴이 있다면 적극 활용해주세요!
+
+**🎯 성공 기준**: 뒤로가기 버튼 클릭 시 모든 마커와 폴리라인이 100% 화면에서 사라지는 것
+
+이 문제를 해결해주시면 정말 감사하겠습니다! 🚀 

--- a/src/api/swagger-api.ts
+++ b/src/api/swagger-api.ts
@@ -169,6 +169,29 @@ export interface TrailListResponse {
   totalElements: number;
 }
 
+// 산책로 상세 조회 응답 타입
+export interface TrailDetailResponse {
+  /** @format int32 */
+  httpStatus: number;
+  message: string;
+  data: {
+    title: string;
+    description: string;
+    location: string;
+    /** @format double */
+    length: number;
+    routeImageUrl?: string;
+    /** @format int32 */
+    reviewCount: number;
+    /** @format double */
+    rating: number;
+    /** @format int64 */
+    pathId: number;
+    startPoint: [number, number]; // [경도, 위도]
+    path: [number, number][]; // [[경도, 위도], [경도, 위도], ...]
+  };
+}
+
 export interface BaseResponseListWalkListResponse {
   /** @format int32 */
   httpStatus?: number;
@@ -850,6 +873,21 @@ export class Api<
     getTrails: (params: RequestParams = {}) =>
       this.request<TrailListResponse, any>({
         path: `/api/trails`,
+        method: 'GET',
+        ...params,
+      }),
+
+    /**
+     * @description 특정 산책로의 상세 정보를 조회합니다.
+     *
+     * @tags 산책로
+     * @name GetTrailById
+     * @summary 산책로 상세 조회
+     * @request GET:/api/trails/{trailId}
+     */
+    getTrailById: (trailId: number, params: RequestParams = {}) =>
+      this.request<TrailDetailResponse, any>({
+        path: `/api/trails/${trailId}`,
         method: 'GET',
         ...params,
       }),

--- a/src/api/swagger-api.ts
+++ b/src/api/swagger-api.ts
@@ -146,6 +146,29 @@ export interface BaseResponseVoid {
   data?: any;
 }
 
+// 산책로 관련 타입 정의
+export interface TrailResponse {
+  /** @format int64 */
+  id: number;
+  name: string;
+  location: string;
+  /** @format double */
+  length: number;
+  /** @format double */
+  rating: number;
+  /** @format int32 */
+  reviewCount: number;
+}
+
+export interface TrailListResponse {
+  /** @format int32 */
+  status: number;
+  message: string;
+  trails: TrailResponse[];
+  /** @format int32 */
+  totalElements: number;
+}
+
 export interface BaseResponseListWalkListResponse {
   /** @format int32 */
   httpStatus?: number;
@@ -813,6 +836,21 @@ export class Api<
         path: `/api/friends/${friendMemberId}`,
         method: 'DELETE',
         secure: true,
+        ...params,
+      }),
+
+    /**
+     * @description 산책로 목록을 조회합니다.
+     *
+     * @tags 산책로
+     * @name GetTrails
+     * @summary 산책로 목록 조회
+     * @request GET:/api/trails
+     */
+    getTrails: (params: RequestParams = {}) =>
+      this.request<TrailListResponse, any>({
+        path: `/api/trails`,
+        method: 'GET',
         ...params,
       }),
   };

--- a/src/components/TrailBottomSheet.tsx
+++ b/src/components/TrailBottomSheet.tsx
@@ -8,6 +8,7 @@ interface TrailBottomSheetProps {
   activeTab: 'trails' | 'weather';
   setActiveTab: (tab: 'trails' | 'weather') => void;
   nearbyTrails: Trail[];
+  isTrailsLoading?: boolean;
   sortOption: string;
   setSortOption: (option: string) => void;
   onTrailCardClick: (trail: Trail) => void;
@@ -19,6 +20,7 @@ const TrailBottomSheet: React.FC<TrailBottomSheetProps> = ({
   activeTab,
   setActiveTab,
   nearbyTrails,
+  isTrailsLoading = false,
   sortOption,
   setSortOption,
   onTrailCardClick
@@ -27,6 +29,7 @@ const TrailBottomSheet: React.FC<TrailBottomSheetProps> = ({
     <BottomSheet
       isOpen={isOpen}
       onClose={onClose}
+      title={activeTab === 'trails' ? '근처 산책로 및 날씨 정보' : '날씨 정보'}
       defaultSnapPoint={60}
       className="safe-area-bottom"
       showBackdrop={false}
@@ -75,53 +78,63 @@ const TrailBottomSheet: React.FC<TrailBottomSheetProps> = ({
         <div className="flex-1 overflow-y-auto">
           {activeTab === 'trails' ? (
             <div className="p-4 space-y-4">
-              {/* 근처 산책로 목록 */}
-              {nearbyTrails.length > 0 ? (
-                nearbyTrails.map((trail, index) => (
-                  <div 
-                    key={index} 
-                    className="flex space-x-3 p-3 bg-white rounded-lg shadow-sm border border-gray-100 cursor-pointer hover:bg-gray-50 transition-colors"
-                    onClick={() => onTrailCardClick(trail)}
-                  >
-                    {/* 이미지 */}
-                    <div className="w-16 h-16 bg-gray-200 rounded-lg flex-shrink-0">
-                      <img
-                        src={trail.image || '/public/test_picture/test_for_success.jpg'}
-                        alt={trail.name}
-                        className="w-full h-full object-cover rounded-lg"
-                      />
-                    </div>
-                    
-                    {/* 정보 */}
-                    <div className="flex-1 min-w-0">
-                      <h3 className="font-semibold text-gray-900 text-sm mb-1">
-                        {trail.name}
-                      </h3>
-                      
-                      {/* 평점 */}
-                      <div className="flex items-center mb-1">
-                        <span className="text-yellow-400 text-xs">★★★★☆</span>
-                        <span className="text-xs text-gray-600 ml-1">
-                          {trail.rating} ({trail.reviewCount})
-                        </span>
-                      </div>
-                      
-                      {/* 설명 */}
-                      <p className="text-xs text-gray-600 mb-1">
-                        {trail.description}
-                      </p>
-                      
-                      {/* 카테고리 */}
-                      <span className="text-xs text-gray-500">
-                        {trail.category}
-                      </span>
-                    </div>
-                  </div>
-                ))
-              ) : (
-                <div className="text-center py-8">
-                  <p className="text-gray-500 text-sm">근처 산책로를 찾는 중...</p>
+              {/* 로딩 상태 */}
+              {isTrailsLoading ? (
+                <div className="flex items-center justify-center py-8">
+                  <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-500 mr-3"></div>
+                  <span className="text-gray-600 text-sm">산책로 목록을 불러오는 중...</span>
                 </div>
+              ) : (
+                <>
+                  {/* 근처 산책로 목록 */}
+                  {nearbyTrails.length > 0 ? (
+                    nearbyTrails.map((trail, index) => (
+                      <div 
+                        key={index} 
+                        className="flex space-x-3 p-3 bg-white rounded-lg shadow-sm border border-gray-100 cursor-pointer hover:bg-gray-50 transition-colors"
+                        onClick={() => onTrailCardClick(trail)}
+                      >
+                        {/* 이미지 */}
+                        <div className="w-16 h-16 bg-gray-200 rounded-lg flex-shrink-0">
+                          <img
+                            src={trail.image || '/public/test_picture/test_for_success.jpg'}
+                            alt={trail.name}
+                            className="w-full h-full object-cover rounded-lg"
+                          />
+                        </div>
+                        
+                        {/* 정보 */}
+                        <div className="flex-1 min-w-0">
+                          <h3 className="font-semibold text-gray-900 text-sm mb-1">
+                            {trail.name}
+                          </h3>
+                          
+                          {/* 평점 */}
+                          <div className="flex items-center mb-1">
+                            <span className="text-yellow-400 text-xs">★★★★☆</span>
+                            <span className="text-xs text-gray-600 ml-1">
+                              {trail.rating} ({trail.reviewCount})
+                            </span>
+                          </div>
+                          
+                          {/* 설명 */}
+                          <p className="text-xs text-gray-600 mb-1">
+                            {trail.description}
+                          </p>
+                          
+                          {/* 카테고리 */}
+                          <span className="text-xs text-gray-500">
+                            {trail.category}
+                          </span>
+                        </div>
+                      </div>
+                    ))
+                  ) : (
+                    <div className="text-center py-8">
+                      <p className="text-gray-500 text-sm">근처 산책로를 찾는 중...</p>
+                    </div>
+                  )}
+                </>
               )}
             </div>
           ) : (

--- a/src/components/TrailDetailCard.tsx
+++ b/src/components/TrailDetailCard.tsx
@@ -57,7 +57,7 @@ const TrailDetailCard: React.FC<TrailDetailCardProps> = ({
     };
 
     fetchTrailDetail();
-  }, [trail.id]);
+  }, [trail.id, onTrailPathUpdate]);
 
   return (
     <div className="absolute bottom-4 left-4 right-4 z-40 pointer-events-auto">

--- a/src/components/TrailDetailCard.tsx
+++ b/src/components/TrailDetailCard.tsx
@@ -1,9 +1,13 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import type { Trail } from '../types/trail';
+import { getTrailById } from '../utils/backendApi';
+import { convertTrailDetailResponseToTrail } from '../utils/converter/trailConverter';
 
 interface TrailDetailCardProps {
-  trail: any;
+  trail: Trail;
   onBack: () => void;
   onStartWalk: () => void;
+  onTrailPathUpdate?: (path: [number, number][]) => void;
   error?: any;
 }
 
@@ -11,8 +15,50 @@ const TrailDetailCard: React.FC<TrailDetailCardProps> = ({
   trail,
   onBack,
   onStartWalk,
+  onTrailPathUpdate,
   error
 }) => {
+  const [detailedTrail, setDetailedTrail] = useState<Trail>(trail);
+  const [isLoading, setIsLoading] = useState(false);
+  const [detailError, setDetailError] = useState<string | null>(null);
+
+  // 상세 정보 조회
+  useEffect(() => {
+    const fetchTrailDetail = async () => {
+      if (!trail.id) return;
+      
+      try {
+        setIsLoading(true);
+        setDetailError(null);
+        
+        console.log('🏃 산책로 상세 정보 조회 시작:', trail.id);
+        const response = await getTrailById(trail.id);
+        
+        if (response.httpStatus === 200 && response.data) {
+          const detailedTrailData = convertTrailDetailResponseToTrail(response);
+          setDetailedTrail(detailedTrailData);
+          console.log('✅ 산책로 상세 정보 조회 성공:', detailedTrailData.name);
+          
+          // 경로 데이터가 있으면 부모 컴포넌트에 전달
+          if (detailedTrailData.path && onTrailPathUpdate) {
+            onTrailPathUpdate(detailedTrailData.path);
+          }
+        } else {
+          throw new Error(`API 응답 오류: ${response.message}`);
+        }
+      } catch (error) {
+        console.error('❌ 산책로 상세 정보 조회 실패:', error);
+        setDetailError('상세 정보를 불러올 수 없습니다.');
+        // 기본 정보는 유지
+        setDetailedTrail(trail);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchTrailDetail();
+  }, [trail.id]);
+
   return (
     <div className="absolute bottom-4 left-4 right-4 z-40 pointer-events-auto">
       <div className="bg-white rounded-lg shadow-lg border border-gray-200 overflow-hidden">
@@ -26,55 +72,76 @@ const TrailDetailCard: React.FC<TrailDetailCardProps> = ({
             <span className="material-icons text-xl">arrow_back</span>
           </button>
           <h2 className="text-lg font-semibold text-gray-900">
-            {trail.name}
+            {isLoading ? '로딩 중...' : detailedTrail.name}
           </h2>
           <div className="w-10"></div> {/* 균형을 위한 빈 공간 */}
         </div>
 
         {/* 콘텐츠 */}
         <div className="p-4">
-          <div className="flex space-x-4">
-            {/* 왼쪽 정보 */}
-            <div className="flex-1">
-              {/* 평점 */}
-              <div className="flex items-center mb-2">
-                <span className="text-yellow-400 text-sm">★★★★☆</span>
-                <span className="text-sm text-gray-600 ml-1">
-                  {trail.rating} ({trail.reviewCount})
-                </span>
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-500 mr-3"></div>
+              <span className="text-gray-600 text-sm">상세 정보를 불러오는 중...</span>
+            </div>
+          ) : (
+            <>
+              <div className="flex space-x-4">
+                {/* 왼쪽 정보 */}
+                <div className="flex-1">
+                  {/* 평점 */}
+                  <div className="flex items-center mb-2">
+                    <span className="text-yellow-400 text-sm">★★★★☆</span>
+                    <span className="text-sm text-gray-600 ml-1">
+                      {detailedTrail.rating} ({detailedTrail.reviewCount})
+                    </span>
+                  </div>
+
+                  {/* 설명 */}
+                  <p className="text-sm text-gray-700 mb-2">
+                    {detailedTrail.description}
+                  </p>
+
+                  {/* 위치 */}
+                  <p className="text-sm text-gray-600 mb-1">
+                    {detailedTrail.location}
+                  </p>
+
+                  {/* 거리 */}
+                  <p className="text-sm text-gray-500">
+                    총 거리: {detailedTrail.distance}km
+                  </p>
+
+                  {/* 에러 메시지 */}
+                  {detailError && (
+                    <p className="text-sm text-red-500 mt-2">
+                      {detailError}
+                    </p>
+                  )}
+                </div>
+
+                {/* 오른쪽 이미지 */}
+                <div className="w-20 h-20 bg-gray-200 rounded-lg flex-shrink-0">
+                  <img
+                    src={detailedTrail.routeImageUrl || detailedTrail.image || '/public/test_picture/test_for_success.jpg'}
+                    alt={detailedTrail.name}
+                    className="w-full h-full object-cover rounded-lg"
+                  />
+                </div>
               </div>
 
-              {/* 설명 */}
-              <p className="text-sm text-gray-700 mb-2">
-                {trail.description} {trail.category}
-              </p>
-
-              {/* 거리 */}
-              <p className="text-sm text-gray-500">
-                내 위치로부터 약 {trail.distance}km
-              </p>
-            </div>
-
-            {/* 오른쪽 이미지 */}
-            <div className="w-20 h-20 bg-gray-200 rounded-lg flex-shrink-0">
-              <img
-                src={trail.image}
-                alt={trail.name}
-                className="w-full h-full object-cover rounded-lg"
-              />
-            </div>
-          </div>
-
-          {/* Walk it! 버튼 */}
-          <div className="mt-4">
-            <button
-              onClick={onStartWalk}
-              disabled={!!error}
-              className="w-full py-3 bg-green-500 text-white rounded-lg shadow-lg hover:bg-green-600 transition-all disabled:bg-gray-400 disabled:cursor-not-allowed font-medium"
-            >
-              Walk it!
-            </button>
-          </div>
+              {/* Walk it! 버튼 */}
+              <div className="mt-4">
+                <button
+                  onClick={onStartWalk}
+                  disabled={!!error}
+                  className="w-full py-3 bg-green-500 text-white rounded-lg shadow-lg hover:bg-green-600 transition-all disabled:bg-gray-400 disabled:cursor-not-allowed font-medium"
+                >
+                  Walk it!
+                </button>
+              </div>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/TrailDetailCard.tsx
+++ b/src/components/TrailDetailCard.tsx
@@ -127,7 +127,7 @@ const TrailDetailCard: React.FC<TrailDetailCardProps> = ({
                 {/* 오른쪽 이미지 */}
                 <div className="w-20 h-20 bg-gray-200 rounded-lg flex-shrink-0">
                   <img
-                    src={detailedTrail.routeImageUrl || detailedTrail.image || '/public/test_picture/test_for_success.jpg'}
+                    src={detailedTrail.routeImageUrl || detailedTrail.image || '/test_picture/test_for_success.jpg'}
                     alt={detailedTrail.name}
                     className="w-full h-full object-cover rounded-lg"
                   />

--- a/src/components/TrailDetailCard.tsx
+++ b/src/components/TrailDetailCard.tsx
@@ -91,7 +91,11 @@ const TrailDetailCard: React.FC<TrailDetailCardProps> = ({
                 <div className="flex-1">
                   {/* 평점 */}
                   <div className="flex items-center mb-2">
-                    <span className="text-yellow-400 text-sm">★★★★☆</span>
+                    <span className="text-yellow-400 text-sm">
+                      {'★'.repeat(Math.floor(detailedTrail.rating))}
+                      {detailedTrail.rating % 1 >= 0.5 ? '☆' : ''}
+                      {'☆'.repeat(5 - Math.ceil(detailedTrail.rating))}
+                    </span>
                     <span className="text-sm text-gray-600 ml-1">
                       {detailedTrail.rating} ({detailedTrail.reviewCount})
                     </span>

--- a/src/components/ui/BottomSheet.tsx
+++ b/src/components/ui/BottomSheet.tsx
@@ -140,13 +140,22 @@ const BottomSheet = ({
             onEscapeKeyDown={onClose}
             onInteractOutside={showBackdrop ? () => onClose() : undefined}
           >
-            {/* 접근성을 위한 숨겨진 제목과 설명 */}
-            <Dialog.Title className="sr-only">
-              {title || '바텀시트'}
-            </Dialog.Title>
-            <Dialog.Description className="sr-only">
-              {title ? `${title} 콘텐츠` : '바텀시트 콘텐츠'}
-            </Dialog.Description>
+            {/* 접근성을 위한 숨겨진 제목과 설명 (title이 없을 때만) */}
+            {!title && (
+              <>
+                <Dialog.Title className="sr-only">
+                  바텀시트
+                </Dialog.Title>
+                <Dialog.Description className="sr-only">
+                  바텀시트 콘텐츠
+                </Dialog.Description>
+              </>
+            )}
+            {title && (
+              <Dialog.Description className="sr-only">
+                {title} 콘텐츠
+              </Dialog.Description>
+            )}
           {/* 핸들 */}
           <div
             className="flex justify-center pt-3 pb-2 cursor-grab active:cursor-grabbing"

--- a/src/components/ui/BottomSheet.tsx
+++ b/src/components/ui/BottomSheet.tsx
@@ -140,6 +140,13 @@ const BottomSheet = ({
             onEscapeKeyDown={onClose}
             onInteractOutside={showBackdrop ? () => onClose() : undefined}
           >
+            {/* 접근성을 위한 숨겨진 제목과 설명 */}
+            <Dialog.Title className="sr-only">
+              {title || '바텀시트'}
+            </Dialog.Title>
+            <Dialog.Description className="sr-only">
+              {title ? `${title} 콘텐츠` : '바텀시트 콘텐츠'}
+            </Dialog.Description>
           {/* 핸들 */}
           <div
             className="flex justify-center pt-3 pb-2 cursor-grab active:cursor-grabbing"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -72,10 +72,10 @@ const Home = () => {
   const [sortOption, setSortOption] = useState('distance');
   const [selectedTrail, setSelectedTrail] = useState<Trail | null>(null);
   const [showTrailDetail, setShowTrailDetail] = useState(false);
-  const [trailMarker, setTrailMarker] = useState<kakao.maps.Marker | null>(null);
-  const [trailPolyline, setTrailPolyline] = useState<kakao.maps.Polyline | null>(null);
-  const [trailStartMarker, setTrailStartMarker] = useState<kakao.maps.Marker | null>(null);
-  const [trailEndMarker, setTrailEndMarker] = useState<kakao.maps.Marker | null>(null);
+  // ✅ useRef 배열로 마커/오버레이/폴리라인 관리 (솔루션 적용)
+  const trailMarkersRef = useRef<kakao.maps.Marker[]>([]);
+  const trailPolylinesRef = useRef<kakao.maps.Polyline[]>([]);
+  const trailOverlaysRef = useRef<kakao.maps.CustomOverlay[]>([]);
   const map = useRef<kakao.maps.Map | null>(null);
   const polyline = useRef<kakao.maps.Polyline | null>(null);
   const markersRef = useRef<kakao.maps.Marker[]>([]);
@@ -144,11 +144,8 @@ const Home = () => {
     setShowTrailDetail(false); // 상세 정보 닫기
     setSelectedTrail(null);
     
-    // 마커 제거
-    if (trailMarker) {
-      trailMarker.setMap(null);
-      setTrailMarker(null);
-    }
+    // ✅ 트레일 요소 일괄 제거
+    clearAllTrailElements();
     
     toast.success('산책을 시작합니다!', {
       description: 'GPS 신호가 안정적인 실외에서 이용해주세요.',
@@ -229,10 +226,8 @@ const Home = () => {
     setShowTrailDetail(true);
     setIsBottomSheetOpen(false); // 바텀시트 닫기
     
-    // 기존 마커 제거
-    if (trailMarker) {
-      trailMarker.setMap(null);
-    }
+    // ✅ 기존 트레일 요소 일괄 제거
+    clearAllTrailElements();
     
     // 지도를 해당 위치로 이동하고 마커 추가
     if (map.current && trail.coordinates) {
@@ -262,13 +257,12 @@ const Home = () => {
         logger.error('❌ 지도 이동 실패:', error);
       }
       
-      // 산책로 마커 생성 및 추가
+      // ✅ 산책로 마커 생성 및 배열에 추가
       const marker = new window.kakao.maps.Marker({
         position: latLng,
         map: map.current,
       });
-      
-      setTrailMarker(marker);
+      trailMarkersRef.current.push(marker);
       
       logger.log('🎯 산책로 마커 생성 완료:', {
         name: trail.name,
@@ -278,36 +272,57 @@ const Home = () => {
     }
   };
 
+  // ✅ 솔루션 적용: 일괄 마커/오버레이/폴리라인 제거 함수
+  const clearAllTrailElements = () => {
+    logger.log('🧹 트레일 요소 일괄 제거 시작');
+    
+    // 1. 마커 제거
+    trailMarkersRef.current.forEach((marker, index) => {
+      marker.setMap(null);
+      logger.log(`🗑️ 마커 ${index + 1} 제거 완료`);
+    });
+    trailMarkersRef.current = [];
+    
+    // 2. 폴리라인 제거
+    trailPolylinesRef.current.forEach((polyline, index) => {
+      polyline.setMap(null);
+      logger.log(`🗑️ 폴리라인 ${index + 1} 제거 완료`);
+    });
+    trailPolylinesRef.current = [];
+    
+    // 3. 커스텀 오버레이 제거 (솔루션의 핵심!)
+    trailOverlaysRef.current.forEach((overlay, index) => {
+      overlay.setMap(null);
+      
+      // 💡 솔루션 핵심: CustomOverlay DOM 수동 제거
+      try {
+        const content = overlay.getContent() as HTMLElement;
+        if (content && content.parentNode) {
+          content.parentNode.removeChild(content);
+          logger.log(`🗑️ 오버레이 ${index + 1} DOM 제거 완료`);
+        }
+      } catch (e) {
+        logger.log(`⚠️ 오버레이 ${index + 1} DOM 제거 실패 (무시)`);
+      }
+      
+      logger.log(`🗑️ 오버레이 ${index + 1} 제거 완료`);
+    });
+    trailOverlaysRef.current = [];
+    
+    logger.log('✅ 모든 트레일 요소 제거 완료');
+  };
+
   // 이전 페이지로 돌아가기
   const handleBackToTrails = () => {
     setShowTrailDetail(false);
     setSelectedTrail(null);
     setIsBottomSheetOpen(true);
     
-    // 산책로 마커 제거
-    if (trailMarker) {
-      trailMarker.setMap(null);
-      setTrailMarker(null);
-      logger.log('🗑️ 산책로 마커 제거 완료');
-    }
+    // ✅ 새로운 일괄 제거 함수 사용
+    clearAllTrailElements();
     
-    // 산책로 경로 제거
-    if (trailPolyline) {
-      trailPolyline.setMap(null);
-      setTrailPolyline(null);
-      logger.log('🗑️ 산책로 경로 제거 완료');
-    }
-    
-    // 시작점/끝점 마커 제거
-    if (trailStartMarker) {
-      trailStartMarker.setMap(null);
-      setTrailStartMarker(null);
-    }
-    if (trailEndMarker) {
-      trailEndMarker.setMap(null);
-      setTrailEndMarker(null);
-    }
-    
+    // ✅ DOM 백업 제거 로직 불필요 (솔루션 적용으로 제거)
+
     // 지도를 기본 위치로 복원 (현재 위치 또는 서울 시청)
     if (map.current) {
       try {
@@ -343,31 +358,20 @@ const Home = () => {
     );
   };
 
-  // 산책로 경로 시각화
+  // ✅ 솔루션 적용: 산책로 경로 시각화 (useRef 배열 방식)
   const handleTrailPathUpdate = (path: [number, number][]) => {
     if (!map.current || path.length === 0) return;
 
     try {
-      // 기존 경로 및 마커 제거
-      if (trailPolyline) {
-        trailPolyline.setMap(null);
-        setTrailPolyline(null);
-      }
-      if (trailStartMarker) {
-        trailStartMarker.setMap(null);
-        setTrailStartMarker(null);
-      }
-      if (trailEndMarker) {
-        trailEndMarker.setMap(null);
-        setTrailEndMarker(null);
-      }
+      // ✅ 기존 모든 트레일 요소 제거 (새로운 일괄 제거 함수 사용)
+      clearAllTrailElements();
 
       // 경로 좌표를 카카오맵 LatLng로 변환 ([경도, 위도] → [위도, 경도])
       const latLngPath = path.map(([lng, lat]) => 
         new window.kakao.maps.LatLng(lat, lng)
       );
 
-      // 폴리라인 생성
+      // ✅ 폴리라인 생성 및 배열에 추가
       const polyline = new window.kakao.maps.Polyline({
         path: latLngPath,
         strokeWeight: 4,
@@ -376,16 +380,16 @@ const Home = () => {
         strokeStyle: 'solid',
         map: map.current,
       });
+      trailPolylinesRef.current.push(polyline);
 
-      setTrailPolyline(polyline);
-
-      // 시작점 마커 생성
+      // ✅ 시작점 마커 생성 및 배열에 추가
       const startMarker = new window.kakao.maps.Marker({
         position: latLngPath[0],
         map: map.current,
       });
+      trailMarkersRef.current.push(startMarker);
 
-      // 시작점 마커에 작은 텍스트 오버레이 추가
+      // ✅ 시작점 오버레이 생성 및 배열에 추가
       const startLabel = document.createElement('div');
       startLabel.style.cssText = 'background:rgba(0,0,0,0.7);color:white;padding:2px 6px;border-radius:3px;font-size:10px;white-space:nowrap;text-align:center;';
       startLabel.textContent = '시작';
@@ -396,16 +400,17 @@ const Home = () => {
         map: map.current,
         yAnchor: 1.5,
       });
-      setTrailStartMarker(startMarker);
+      trailOverlaysRef.current.push(startOverlay);
 
-      // 끝점 마커 생성 (경로가 2개 이상일 때)
+      // ✅ 끝점 마커 생성 (경로가 2개 이상일 때) 및 배열에 추가
       if (latLngPath.length > 1) {
         const endMarker = new window.kakao.maps.Marker({
           position: latLngPath[latLngPath.length - 1],
           map: map.current,
         });
+        trailMarkersRef.current.push(endMarker);
 
-        // 끝점 마커에 작은 텍스트 오버레이 추가
+        // 끝점 오버레이 생성 및 배열에 추가
         const endLabel = document.createElement('div');
         endLabel.style.cssText = 'background:rgba(0,0,0,0.7);color:white;padding:2px 6px;border-radius:3px;font-size:10px;white-space:nowrap;text-align:center;';
         endLabel.textContent = '끝';
@@ -416,7 +421,7 @@ const Home = () => {
           map: map.current,
           yAnchor: 1.5,
         });
-        setTrailEndMarker(endMarker);
+        trailOverlaysRef.current.push(endOverlay);
       }
 
       // 경로가 모두 보이도록 지도 범위 조정

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -9,6 +9,8 @@ import { isOAuthCallback } from '@/utils/oauth';
 import TrailBottomSheet from '@/components/TrailBottomSheet';
 import TrailDetailCard from '@/components/TrailDetailCard';
 import type { Trail } from '@/types/trail';
+import { getTrails } from '@/utils/backendApi';
+import { convertTrailResponseArrayToTrailArray } from '@/utils/converter/trailConverter';
 import './index.css';
 import '@/styles/rootlayout.css';
 
@@ -66,6 +68,7 @@ const Home = () => {
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<'trails' | 'weather'>('trails');
   const [nearbyTrails, setNearbyTrails] = useState<Trail[]>([]);
+  const [isTrailsLoading, setIsTrailsLoading] = useState(false);
   const [sortOption, setSortOption] = useState('distance');
   const [selectedTrail, setSelectedTrail] = useState<Trail | null>(null);
   const [showTrailDetail, setShowTrailDetail] = useState(false);
@@ -161,66 +164,47 @@ const Home = () => {
 
   // 근처 산책로 데이터 가져오기
   const fetchNearbyTrails = useCallback(async () => {
-    if (!position) return;
-
     try {
-      // 임시 데이터 (실제로는 API 호출)
-      const mockTrails = [
-        {
-          id: 1,
-          name: '일산 호수공원',
-          rating: 4.6,
-          reviewCount: 3369,
-          description: '산책, 예술, 이벤트를 즐길 수 있는',
-          category: '호숫가 공원',
-          image: '/public/test_picture/test_for_success.jpg',
-          distance: 0.8,
-          coordinates: { lat: 37.657019, lng: 126.763746 }
-        },
-        {
-          id: 2,
-          name: '고양시 한강공원',
-          rating: 4.3,
-          reviewCount: 2156,
-          description: '한강변을 따라 걷는 산책로',
-          category: '강변 공원',
-          image: '/public/test_picture/test_for_success.jpg',
-          distance: 1.2,
-          coordinates: { lat: 37.6612, lng: 126.7715 }
-        },
-        {
-          id: 3,
-          name: '고양시립도서관 주변',
-          rating: 4.1,
-          reviewCount: 892,
-          description: '조용하고 평화로운 산책 환경',
-          category: '도시 공원',
-          image: '/public/test_picture/test_for_success.jpg',
-          distance: 1.5,
-          coordinates: { lat: 37.6598, lng: 126.7682 }
+      setIsTrailsLoading(true);
+      logger.log('🏃 산책로 목록 조회 시작');
+      
+      // API 호출
+      const response = await getTrails();
+      
+      if (response.status === 200 && response.trails) {
+        // API 응답을 Trail 타입으로 변환
+        const trails = convertTrailResponseArrayToTrailArray(response.trails);
+        
+        // 정렬 옵션에 따라 데이터 정렬
+        let sortedTrails = [...trails];
+        switch (sortOption) {
+          case 'distance':
+            sortedTrails.sort((a, b) => a.distance - b.distance);
+            break;
+          case 'rating':
+            sortedTrails.sort((a, b) => b.rating - a.rating);
+            break;
+          case 'popularity':
+            sortedTrails.sort((a, b) => b.reviewCount - a.reviewCount);
+            break;
         }
-      ];
 
-      // 정렬 옵션에 따라 데이터 정렬
-      let sortedTrails = [...mockTrails];
-      switch (sortOption) {
-        case 'distance':
-          sortedTrails.sort((a, b) => a.distance - b.distance);
-          break;
-        case 'rating':
-          sortedTrails.sort((a, b) => b.rating - a.rating);
-          break;
-        case 'popularity':
-          sortedTrails.sort((a, b) => b.reviewCount - a.reviewCount);
-          break;
+        setNearbyTrails(sortedTrails);
+        logger.log('✅ 산책로 목록 조회 성공:', {
+          totalCount: response.totalElements,
+          loadedCount: trails.length,
+          sortOption
+        });
+      } else {
+        throw new Error(`API 응답 오류: ${response.message}`);
       }
-
-      setNearbyTrails(sortedTrails);
     } catch (error) {
-      console.error('근처 산책로 데이터 가져오기 실패:', error);
+      logger.error('❌ 근처 산책로 데이터 가져오기 실패:', error);
       toast.error('근처 산책로 정보를 가져올 수 없습니다.');
+    } finally {
+      setIsTrailsLoading(false);
     }
-  }, [position, sortOption]);
+  }, [sortOption]);
 
   // 바텀시트가 열릴 때 또는 탭 변경 시 근처 산책로 데이터 가져오기
   useEffect(() => {
@@ -1089,6 +1073,7 @@ const Home = () => {
           activeTab={activeTab}
           setActiveTab={setActiveTab}
           nearbyTrails={nearbyTrails}
+          isTrailsLoading={isTrailsLoading}
           sortOption={sortOption}
           setSortOption={setSortOption}
           onTrailCardClick={handleTrailCardClick}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -73,6 +73,9 @@ const Home = () => {
   const [selectedTrail, setSelectedTrail] = useState<Trail | null>(null);
   const [showTrailDetail, setShowTrailDetail] = useState(false);
   const [trailMarker, setTrailMarker] = useState<kakao.maps.Marker | null>(null);
+  const [trailPolyline, setTrailPolyline] = useState<kakao.maps.Polyline | null>(null);
+  const [trailStartMarker, setTrailStartMarker] = useState<kakao.maps.Marker | null>(null);
+  const [trailEndMarker, setTrailEndMarker] = useState<kakao.maps.Marker | null>(null);
   const map = useRef<kakao.maps.Map | null>(null);
   const polyline = useRef<kakao.maps.Polyline | null>(null);
   const markersRef = useRef<kakao.maps.Marker[]>([]);
@@ -288,6 +291,23 @@ const Home = () => {
       logger.log('🗑️ 산책로 마커 제거 완료');
     }
     
+    // 산책로 경로 제거
+    if (trailPolyline) {
+      trailPolyline.setMap(null);
+      setTrailPolyline(null);
+      logger.log('🗑️ 산책로 경로 제거 완료');
+    }
+    
+    // 시작점/끝점 마커 제거
+    if (trailStartMarker) {
+      trailStartMarker.setMap(null);
+      setTrailStartMarker(null);
+    }
+    if (trailEndMarker) {
+      trailEndMarker.setMap(null);
+      setTrailEndMarker(null);
+    }
+    
     // 지도를 기본 위치로 복원 (현재 위치 또는 서울 시청)
     if (map.current) {
       try {
@@ -321,6 +341,96 @@ const Home = () => {
       { lat: pos1.getLat(), lng: pos1.getLng() },
       { lat: pos2.getLat(), lng: pos2.getLng() }
     );
+  };
+
+  // 산책로 경로 시각화
+  const handleTrailPathUpdate = (path: [number, number][]) => {
+    if (!map.current || path.length === 0) return;
+
+    try {
+      // 기존 경로 및 마커 제거
+      if (trailPolyline) {
+        trailPolyline.setMap(null);
+        setTrailPolyline(null);
+      }
+      if (trailStartMarker) {
+        trailStartMarker.setMap(null);
+        setTrailStartMarker(null);
+      }
+      if (trailEndMarker) {
+        trailEndMarker.setMap(null);
+        setTrailEndMarker(null);
+      }
+
+      // 경로 좌표를 카카오맵 LatLng로 변환 ([경도, 위도] → [위도, 경도])
+      const latLngPath = path.map(([lng, lat]) => 
+        new window.kakao.maps.LatLng(lat, lng)
+      );
+
+      // 폴리라인 생성
+      const polyline = new window.kakao.maps.Polyline({
+        path: latLngPath,
+        strokeWeight: 4,
+        strokeColor: '#4CAF50', // 초록색
+        strokeOpacity: 0.8,
+        strokeStyle: 'solid',
+        map: map.current,
+      });
+
+      setTrailPolyline(polyline);
+
+      // 시작점 마커 생성
+      const startMarker = new window.kakao.maps.Marker({
+        position: latLngPath[0],
+        map: map.current,
+      });
+
+      // 시작점 마커에 작은 텍스트 오버레이 추가
+      const startLabel = document.createElement('div');
+      startLabel.style.cssText = 'background:rgba(0,0,0,0.7);color:white;padding:2px 6px;border-radius:3px;font-size:10px;white-space:nowrap;text-align:center;';
+      startLabel.textContent = '시작';
+      
+      const startOverlay = new window.kakao.maps.CustomOverlay({
+        position: latLngPath[0],
+        content: startLabel,
+        map: map.current,
+        yAnchor: 1.5,
+      });
+      setTrailStartMarker(startMarker);
+
+      // 끝점 마커 생성 (경로가 2개 이상일 때)
+      if (latLngPath.length > 1) {
+        const endMarker = new window.kakao.maps.Marker({
+          position: latLngPath[latLngPath.length - 1],
+          map: map.current,
+        });
+
+        // 끝점 마커에 작은 텍스트 오버레이 추가
+        const endLabel = document.createElement('div');
+        endLabel.style.cssText = 'background:rgba(0,0,0,0.7);color:white;padding:2px 6px;border-radius:3px;font-size:10px;white-space:nowrap;text-align:center;';
+        endLabel.textContent = '끝';
+        
+        const endOverlay = new window.kakao.maps.CustomOverlay({
+          position: latLngPath[latLngPath.length - 1],
+          content: endLabel,
+          map: map.current,
+          yAnchor: 1.5,
+        });
+        setTrailEndMarker(endMarker);
+      }
+
+      // 경로가 모두 보이도록 지도 범위 조정
+      const bounds = new window.kakao.maps.LatLngBounds();
+      latLngPath.forEach(latLng => bounds.extend(latLng));
+      map.current.setBounds(bounds);
+
+      logger.log('✅ 산책로 경로 시각화 완료:', {
+        pathLength: path.length,
+        bounds: bounds.toString()
+      });
+    } catch (error) {
+      logger.error('❌ 산책로 경로 시각화 실패:', error);
+    }
   };
 
   // 위치 업데이트 시 경로 그리기
@@ -1062,6 +1172,7 @@ const Home = () => {
             trail={selectedTrail}
             onBack={handleBackToTrails}
             onStartWalk={handleStartWalk}
+            onTrailPathUpdate={handleTrailPathUpdate}
             error={error}
           />
         )}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -171,7 +171,7 @@ const Home = () => {
       // API 호출
       const response = await getTrails();
       
-      if (response.status === 200 && response.trails) {
+      if (response.status === 200 && response.trails && Array.isArray(response.trails)) {
         // API 응답을 Trail 타입으로 변환
         const trails = convertTrailResponseArrayToTrailArray(response.trails);
         

--- a/src/types/trail.ts
+++ b/src/types/trail.ts
@@ -12,6 +12,12 @@ export interface Trail {
     lat: number;
     lng: number;
   };
+  // 상세 정보 (API에서 추가로 제공되는 필드들)
+  location?: string;
+  routeImageUrl?: string;
+  pathId?: number;
+  startPoint?: [number, number]; // [경도, 위도]
+  path?: [number, number][]; // [[경도, 위도], [경도, 위도], ...]
 }
 
 // GeoJSON 타입 정의

--- a/src/utils/backendApi.ts
+++ b/src/utils/backendApi.ts
@@ -351,7 +351,7 @@ const getMockTrailById = async (trailId: number): Promise<TrailDetailResponse> =
     message: '단건 조회 성공',
     data: {
       title: '남산 둘레길',
-      description: '남산 둘레기를 돌아보는 초급 코스입니다.',
+      description: '남산 둘레길을 돌아보는 초급 코스입니다.',
       location: '서울 중구 남산공원',
       length: 3.8,
       routeImageUrl: 'https://example.com/images/namsan-trail.png',

--- a/src/utils/backendApi.ts
+++ b/src/utils/backendApi.ts
@@ -1,16 +1,13 @@
 import type { GeoJSONFeatureCollection } from '../types/trail';
+import type { TrailListResponse, TrailResponse } from '../api/swagger-api';
+import type { Trail } from '../types/trail';
 import type { 
-  WalkRecordsResponse, 
-  WalkRecordDetailResponse, 
-  CreateWalkRecordRequest,
-  CreateWalkRecordResponse,
-  WalkPathDetailResponse,
-  WalkPathsResponse,
+  WalkRecord,
+  WalkListResponse,
   WalkStartApiResponse,
   WalkEventApiResponse,
   WalkCreateApiResponse,
   WalkDeleteApiResponse,
-  WalkListResponse,
   WalkCreateRequest
 } from '../types/walk';
 import { getTrailPaths as getMockTrailPaths } from './mockTrailApi';
@@ -251,4 +248,76 @@ export const getApiModeInfo = () => {
     baseUrl: import.meta.env.VITE_API_BASE_URL,
     environment: import.meta.env.MODE,
   };
+};
+
+/**
+ * 실제 산책로 목록 조회 API
+ */
+const getRealTrails = async (): Promise<TrailListResponse> => {
+  const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/api/trails`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`산책로 API 호출 실패: ${response.status}`);
+  }
+
+  return response.json();
+};
+
+/**
+ * Mock 산책로 데이터 (개발용)
+ */
+const getMockTrails = async (): Promise<TrailListResponse> => {
+  // 개발용 Mock 데이터
+  const mockTrails: TrailResponse[] = [
+    {
+      id: 1,
+      name: '한강공원 산책로',
+      location: '서울특별시 영등포구',
+      length: 5.2,
+      rating: 4.7,
+      reviewCount: 35,
+    },
+    {
+      id: 2,
+      name: '남산 둘레길',
+      location: '서울특별시 중구',
+      length: 3.1,
+      rating: 4.5,
+      reviewCount: 28,
+    },
+    {
+      id: 3,
+      name: '북서울꿈의숲',
+      location: '서울특별시 강북구',
+      length: 2.8,
+      rating: 4.3,
+      reviewCount: 22,
+    },
+  ];
+
+  return {
+    status: 200,
+    message: '산책로 리스트 조회 성공',
+    trails: mockTrails,
+    totalElements: mockTrails.length,
+  };
+};
+
+/**
+ * 환경에 따라 적절한 산책로 API 함수 반환
+ */
+export const getTrails = async (): Promise<TrailListResponse> => {
+  if (isMockMode()) {
+    console.log('🔧 Mock API 모드로 산책로 조회');
+    return getMockTrails();
+  } else {
+    console.log('🚀 실제 API 모드로 산책로 조회');
+    return getRealTrails();
+  }
 }; 

--- a/src/utils/backendApi.ts
+++ b/src/utils/backendApi.ts
@@ -1,5 +1,5 @@
 import type { GeoJSONFeatureCollection } from '../types/trail';
-import type { TrailListResponse, TrailResponse } from '../api/swagger-api';
+import type { TrailListResponse, TrailResponse, TrailDetailResponse } from '../api/swagger-api';
 import type { Trail } from '../types/trail';
 import type { 
   WalkRecord,
@@ -319,5 +319,70 @@ export const getTrails = async (): Promise<TrailListResponse> => {
   } else {
     console.log('🚀 실제 API 모드로 산책로 조회');
     return getRealTrails();
+  }
+};
+
+/**
+ * 실제 산책로 상세 조회 API
+ */
+const getRealTrailById = async (trailId: number): Promise<TrailDetailResponse> => {
+  const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/api/trails/${trailId}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`산책로 상세 조회 API 호출 실패: ${response.status}`);
+  }
+
+  return response.json();
+};
+
+/**
+ * Mock 산책로 상세 데이터 (개발용)
+ */
+const getMockTrailById = async (trailId: number): Promise<TrailDetailResponse> => {
+  // 개발용 Mock 데이터
+  const mockTrailDetail: TrailDetailResponse = {
+    httpStatus: 200,
+    message: '단건 조회 성공',
+    data: {
+      title: '남산 둘레길',
+      description: '남산 둘레기를 돌아보는 초급 코스입니다.',
+      location: '서울 중구 남산공원',
+      length: 3.8,
+      routeImageUrl: 'https://example.com/images/namsan-trail.png',
+      reviewCount: 25,
+      rating: 4.3,
+      pathId: trailId,
+      startPoint: [126.75791835403612, 37.662510637017874],
+      path: [
+        [126.75791835403612, 37.662510637017874],
+        [126.75790151956403, 37.66262761454681],
+        [126.75789029658108, 37.662723861742975],
+        [126.75790900155192, 37.66283343532169],
+        [126.75795763447428, 37.662935605134706],
+        [126.75809792174988, 37.66306886989648],
+        [126.75818770560676, 37.66312069501714]
+      ]
+    }
+  };
+
+  return mockTrailDetail;
+};
+
+/**
+ * 환경에 따라 적절한 산책로 상세 조회 API 함수 반환
+ */
+export const getTrailById = async (trailId: number): Promise<TrailDetailResponse> => {
+  if (isMockMode()) {
+    console.log('🔧 Mock API 모드로 산책로 상세 조회:', trailId);
+    return getMockTrailById(trailId);
+  } else {
+    console.log('🚀 실제 API 모드로 산책로 상세 조회:', trailId);
+    return getRealTrailById(trailId);
   }
 }; 

--- a/src/utils/converter/trailConverter.ts
+++ b/src/utils/converter/trailConverter.ts
@@ -6,8 +6,10 @@ import type {
   TrailPathData,
   CourseStyle,
   KakaoMapPolylineOptions,
-  KakaoMapMarkerOptions
-} from '../types/trail';
+  KakaoMapMarkerOptions,
+  Trail
+} from '../../types/trail';
+import type { TrailResponse } from '@/api/swagger-api';
 
 /**
  * GeoJSON 좌표를 카카오 맵 LatLng 객체로 변환
@@ -244,4 +246,28 @@ export const createPolylineFromCoordinates = (
     strokeStyle: style.strokeStyle || defaultStyle.strokeStyle,
     zIndex: 1
   };
+}; 
+
+/**
+ * API 응답의 TrailResponse를 Trail 타입으로 변환
+ */
+export const convertTrailResponseToTrail = (trailResponse: TrailResponse): Trail => {
+  return {
+    id: trailResponse.id,
+    name: trailResponse.name,
+    rating: trailResponse.rating,
+    reviewCount: trailResponse.reviewCount,
+    description: trailResponse.location, // location을 description으로 사용
+    category: '산책로', // 기본 카테고리
+    distance: trailResponse.length,
+    image: undefined, // API에서 이미지 정보가 없으므로 undefined
+    coordinates: undefined, // API에서 좌표 정보가 없으므로 undefined
+  };
+};
+
+/**
+ * API 응답의 TrailResponse 배열을 Trail 배열로 변환
+ */
+export const convertTrailResponseArrayToTrailArray = (trailResponses: TrailResponse[]): Trail[] => {
+  return trailResponses.map(convertTrailResponseToTrail);
 }; 

--- a/src/utils/converter/trailConverter.ts
+++ b/src/utils/converter/trailConverter.ts
@@ -9,7 +9,7 @@ import type {
   KakaoMapMarkerOptions,
   Trail
 } from '../../types/trail';
-import type { TrailResponse } from '@/api/swagger-api';
+import type { TrailResponse, TrailDetailResponse } from '@/api/swagger-api';
 
 /**
  * GeoJSON 좌표를 카카오 맵 LatLng 객체로 변환
@@ -270,4 +270,32 @@ export const convertTrailResponseToTrail = (trailResponse: TrailResponse): Trail
  */
 export const convertTrailResponseArrayToTrailArray = (trailResponses: TrailResponse[]): Trail[] => {
   return trailResponses.map(convertTrailResponseToTrail);
+};
+
+/**
+ * API 응답의 TrailDetailResponse를 Trail 타입으로 변환
+ */
+export const convertTrailDetailResponseToTrail = (trailDetailResponse: TrailDetailResponse): Trail => {
+  const { data } = trailDetailResponse;
+  
+  return {
+    id: data.pathId,
+    name: data.title,
+    rating: data.rating,
+    reviewCount: data.reviewCount,
+    description: data.description,
+    category: '산책로', // 기본 카테고리
+    distance: data.length,
+    image: data.routeImageUrl,
+    coordinates: data.startPoint ? {
+      lat: data.startPoint[1], // 위도
+      lng: data.startPoint[0], // 경도
+    } : undefined,
+    // 상세 정보
+    location: data.location,
+    routeImageUrl: data.routeImageUrl,
+    pathId: data.pathId,
+    startPoint: data.startPoint,
+    path: data.path,
+  };
 }; 

--- a/src/utils/converter/trailConverter.ts
+++ b/src/utils/converter/trailConverter.ts
@@ -257,11 +257,12 @@ export const convertTrailResponseToTrail = (trailResponse: TrailResponse): Trail
     name: trailResponse.name,
     rating: trailResponse.rating,
     reviewCount: trailResponse.reviewCount,
-    description: trailResponse.location, // location을 description으로 사용
+    description: '', // 기본 설명 (API에서 description 필드가 없음)
     category: '산책로', // 기본 카테고리
     distance: trailResponse.length,
     image: undefined, // API에서 이미지 정보가 없으므로 undefined
     coordinates: undefined, // API에서 좌표 정보가 없으므로 undefined
+    location: trailResponse.location, // location 필드로 올바르게 매핑
   };
 };
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -25,6 +25,7 @@ declare global {
         LatLng: new (lat: number, lng: number) => kakao.maps.LatLng;
         Marker: new (options: kakao.maps.MarkerOptions) => kakao.maps.Marker;
         Polyline: new (options: kakao.maps.PolylineOptions) => kakao.maps.Polyline;
+        LatLngBounds: new () => kakao.maps.LatLngBounds;
         InfoWindow: new (options: kakao.maps.InfoWindowOptions) => kakao.maps.InfoWindow;
         MapOptions: {
           center: kakao.maps.LatLng;
@@ -57,12 +58,20 @@ declare global {
         panTo(latLng: LatLng): void;
         getLevel(): number;
         getCenter(): LatLng;
+        setBounds(bounds: LatLngBounds): void;
       }
       
       class LatLng {
         constructor(lat: number, lng: number);
         getLat(): number;
         getLng(): number;
+      }
+      
+      class LatLngBounds {
+        constructor();
+        extend(latLng: LatLng): void;
+        getSouthWest(): LatLng;
+        getNorthEast(): LatLng;
       }
       
       class Marker {
@@ -76,6 +85,13 @@ declare global {
         setPath(path: LatLng[]): void;
         setMap(map: Map | null): void;
         setOptions(options: Partial<PolylineOptions>): void;
+      }
+      
+      class LatLngBounds {
+        constructor();
+        extend(latLng: LatLng): void;
+        getSouthWest(): LatLng;
+        getNorthEast(): LatLng;
       }
       
       class InfoWindow {

--- a/카카오맵_마커_폴리라인_제거_문제_분석_리포트.md
+++ b/카카오맵_마커_폴리라인_제거_문제_분석_리포트.md
@@ -1,0 +1,173 @@
+# 카카오맵 마커 및 폴리라인 제거 문제 분석 리포트
+
+## 🚨 문제 개요
+
+React TypeScript 환경에서 **카카오맵 API를 통해 생성한 마커(Marker)와 폴리라인(Polyline)이 `setMap(null)` 호출 후에도 화면에서 사라지지 않는 문제**가 발생하고 있습니다.
+
+## 📋 기술 스택 및 환경
+
+- **프레임워크**: React 18 + TypeScript + Vite
+- **지도 API**: 카카오맵 JavaScript API
+- **상태 관리**: React useState hooks
+- **빌드 도구**: Vite
+- **브라우저**: Chrome, Safari 등 모던 브라우저
+
+## 🔍 문제 상세 설명
+
+### 현재 구현 방식
+
+```typescript
+// 마커 생성
+const marker = new window.kakao.maps.Marker({
+  position: latLng,
+  map: map.current,
+});
+setTrailMarker(marker);
+
+// CustomOverlay 생성
+const startLabel = document.createElement('div');
+startLabel.textContent = '시작';
+const startOverlay = new window.kakao.maps.CustomOverlay({
+  position: latLng,
+  content: startLabel,
+  map: map.current,
+});
+setTrailStartOverlay(startOverlay);
+
+// 폴리라인 생성
+const polyline = new window.kakao.maps.Polyline({
+  path: latLngPath,
+  strokeWeight: 4,
+  strokeColor: '#4CAF50',
+  map: map.current,
+});
+setTrailPolyline(polyline);
+```
+
+### 시도한 제거 방법들
+
+```typescript
+// 방법 1: 기본 카카오맵 API 사용
+if (trailMarker) {
+  trailMarker.setMap(null);
+  setTrailMarker(null);
+}
+
+// 방법 2: setVisible 추가
+if (trailMarker) {
+  trailMarker.setVisible(false);
+  trailMarker.setMap(null);
+  setTrailMarker(null);
+}
+
+// 방법 3: DOM 직접 조작
+document.querySelectorAll('[data-trail-element]').forEach(el => el.remove());
+
+// 방법 4: 지도 relayout
+map.current.relayout();
+```
+
+### 🚫 발생하는 문제들
+
+1. **시각적 잔존**: `setMap(null)` 호출 후에도 마커와 폴리라인이 화면에 계속 표시됨
+2. **React State 비동기**: `setTimeout` 내부에서 stale state 참조 문제
+3. **DOM 요소 재생성**: 카카오맵이 내부적으로 DOM 요소를 다시 생성하는 것으로 추정
+4. **부작용**: 과도한 DOM 조작으로 지도 UI 손상
+
+## 🔬 근본 원인 분석
+
+### 추정되는 원인들
+
+1. **카카오맵 내부 캐싱**: 카카오맵이 내부적으로 마커/폴리라인 정보를 캐싱하여 `setMap(null)` 후에도 재렌더링
+2. **React 라이프사이클 충돌**: React의 상태 업데이트와 카카오맵의 DOM 조작 타이밍 문제
+3. **DOM 참조 문제**: `createElement`로 생성한 DOM 요소가 카카오맵 내부에서 복사/캐싱됨
+4. **지도 타일 리렌더링**: 지도 이동/줌 시 마커들이 다시 그려짐
+
+### 로그 분석 결과
+
+```
+✅ 객체 0 visibility 비활성화
+🗑️ 객체 0 지도에서 제거 완료
+✅ 객체 1 visibility 비활성화  
+🗑️ 객체 1 지도에서 제거 완료
+// ... API 호출은 성공하지만 화면에서 사라지지 않음
+```
+
+## 💡 요청사항
+
+다음 방법들 중 어떤 것이 가장 효과적일지, 또는 다른 해결책이 있는지 조언을 구합니다:
+
+### 옵션 A: 카카오맵 완전 재초기화
+```typescript
+// 지도 컨테이너를 완전히 제거하고 새로 생성
+const mapContainer = document.getElementById('map');
+mapContainer.innerHTML = '';
+// 새로운 지도 인스턴스 생성
+```
+
+### 옵션 B: 지도 인스턴스 교체
+```typescript
+// 기존 지도 인스턴스를 null로 설정하고 새로 생성
+map.current = null;
+// 새로운 카카오맵 인스턴스 생성
+```
+
+### 옵션 C: 강제 DOM 조작 + API 조합
+```typescript
+// 1단계: 카카오맵 API로 제거
+marker.setMap(null);
+// 2단계: DOM에서 직접 제거 
+document.querySelectorAll('특정셀렉터').forEach(el => el.remove());
+// 3단계: 지도 강제 리렌더링
+map.relayout();
+```
+
+### 옵션 D: 마커 생성 방식 변경
+```typescript
+// data-attribute 추가로 추적 가능하게 만들기
+const element = document.createElement('div');
+element.setAttribute('data-marker-id', uniqueId);
+element.setAttribute('data-removable', 'true');
+```
+
+## 🎯 핵심 질문들
+
+1. **카카오맵의 내부 동작**: `setMap(null)` 호출 시 카카오맵이 실제로 DOM에서 요소를 제거하는가?
+2. **타이밍 이슈**: React 상태 업데이트와 카카오맵 DOM 조작의 최적 타이밍은?
+3. **메모리 누수**: 제대로 제거되지 않은 마커들이 메모리 누수를 일으키는가?
+4. **대안 API**: CustomOverlay 대신 InfoWindow나 다른 API를 사용하는 것이 나은가?
+
+## 🔧 현재 구현된 해결책 (부분적)
+
+```typescript
+const handleBackToTrails = () => {
+  // 1단계: 카카오맵 API 제거
+  if (trailMarker) {
+    trailMarker.setMap(null);
+    setTrailMarker(null);
+  }
+  
+  // 2단계: DOM 백업 제거 (100ms 지연)
+  setTimeout(() => {
+    const elements = document.querySelectorAll('*');
+    elements.forEach(el => {
+      if (el.textContent === '시작' || el.textContent === '끝') {
+        el.remove();
+      }
+    });
+  }, 100);
+};
+```
+
+## 🙏 도움 요청
+
+**이 문제를 겪어본 경험이 있거나, 카카오맵 API에 대한 깊은 이해가 있는 분의 조언을 구합니다.**
+
+특히 다음 사항들에 대한 구체적인 해결책을 알고 있다면 공유해주세요:
+
+- 카카오맵에서 마커/폴리라인을 100% 확실하게 제거하는 방법
+- React와 카카오맵 API 간의 상태 동기화 베스트 프랙티스  
+- DOM 조작 없이 순수 카카오맵 API만으로 해결하는 방법
+- 이 문제를 근본적으로 방지하는 설계 패턴
+
+코드 예시와 함께 답변해주시면 매우 감사하겠습니다! 🚀 


### PR DESCRIPTION
# 🗺️ 산책로 API 연동 및 경로 시각화 구현

## 연관된 이슈
#56 

## 📋 개요
산책로 목록 조회 및 상세조회 API를 연동하고, 산책로 경로를 카카오맵에 시각화하는 기능을 구현했습니다.

## 🎯 주요 기능

### 1. 산책로 목록 조회 API 연동
- **엔드포인트**: `GET /api/trails`
- **기능**: 근처 산책로 목록을 바텀시트에 표시
- **응답 데이터**: 산책로 이름, 위치, 길이, 평점, 리뷰 수
- **Mock API 지원**: 개발 환경에서 Mock 데이터 사용

### 2. 산책로 상세조회 API 연동
- **엔드포인트**: `GET /api/trails/{trailId}`
- **기능**: 선택한 산책로의 상세 정보 조회
- **응답 데이터**: 상세 설명, 경로 이미지, 시작점/끝점 좌표, 경로 데이터
- **Path Variable**: trailId를 통한 동적 조회

### 3. 경로 시각화 구현
- **폴리라인**: 산책로 경로를 초록색 선으로 표시
- **시작/끝 마커**: 작은 라벨로 시작점과 끝점 표시
- **자동 범위 조정**: 경로 전체가 보이도록 지도 범위 자동 조정
- **기존 요소 제거**: 새로운 경로 표시 시 기존 경로/마커 자동 제거

## 🔧 기술적 구현

### API 클라이언트
```typescript
// 산책로 목록 조회
getTrails(): Promise<TrailListResponse>

// 산책로 상세조회
getTrailById(trailId: number): Promise<TrailDetailResponse>
```

### 데이터 변환
```typescript
// API 응답을 프론트엔드 타입으로 변환
convertTrailResponseArrayToTrailArray(response: TrailListResponse): Trail[]
convertTrailDetailResponseToTrail(response: TrailDetailResponse): Trail
```

### 타입 정의
```typescript
interface Trail {
  id: number;
  name: string;
  rating: number;
  reviewCount: number;
  description: string;
  category: string;
  distance: number;
  image?: string;
  coordinates?: { lat: number; lng: number };
  location?: string;
  routeImageUrl?: string;
  pathId?: number;
  startPoint?: [number, number];
  path?: [number, number][];
}
```

## 📁 변경된 파일

### API 관련
- `src/api/swagger-api.ts` - API 클라이언트 및 타입 정의
- `src/utils/backendApi.ts` - Mock/실제 API 분기 처리
- `src/utils/converter/trailConverter.ts` - 데이터 변환 함수

### 컴포넌트
- `src/components/TrailDetailCard.tsx` - 상세조회 API 연동 및 경로 전달
- `src/pages/index.tsx` - 경로 시각화 및 지도 인터랙션

### 타입 정의
- `src/types/trail.ts` - Trail 인터페이스 확장
- `src/vite-env.d.ts` - 카카오맵 타입 확장

## 🎨 UI/UX 개선

### 바텀시트
- 로딩 상태 표시
- 산책로 목록 탭과 날씨 탭 구분
- 접근성 개선 (Dialog Title/Description 추가)

### 상세 카드
- 상세 정보 표시 (위치, 설명, 거리, 이미지)
- 로딩 스피너 및 에러 처리
- 뒤로가기 버튼 접근성 개선

### 지도 시각화
- 초록색 폴리라인으로 경로 표시
- 작은 라벨로 시작/끝점 표시
- 자동 지도 범위 조정

## 🔍 API 스펙 준수

### 산책로 목록 조회
```json
{
  "status": 200,
  "message": "산책로 리스트 조회 성공",
  "trails": [
    {
      "id": 1,
      "name": "한강공원 산책로",
      "location": "서울특별시 영등포구",
      "length": 5.2,
      "rating": 4.7,
      "reviewCount": 35
    }
  ]
}
```

### 산책로 상세조회
```json
{
  "httpStatus": 200,
  "message": "단건 조회 성공",
  "data": {
    "title": "남산 둘레길",
    "description": "남산 둘레기를 돌아보는 초급 코스입니다.",
    "location": "서울 중구 ...",
    "length": 3.8,
    "routeImageUrl": "https://example.com/images/namsan-trail.png",
    "reviewCount": 25,
    "rating": 4.3,
    "startPoint": [126.75791835403612, 37.662510637017874],
    "path": [
      [126.75791835403612, 37.662510637017874],
      [126.75790151956403, 37.66262761454681]
    ]
  }
}
```

## 🚀 환경 설정

### Mock API 모드
- 개발 환경에서 Mock 데이터 사용
- `backendApi.ts`에서 Mock/실제 API 분기 처리
- 실제 API 연동 시 Mock 모드 비활성화

### 타입 안전성
- TypeScript strict 모드 준수
- API 응답 타입 정의
- 런타임 에러 방지

## 🧪 테스트 시나리오

1. **산책로 목록 조회**
   - 바텀시트 열기 → 근처 산책로 탭 선택
   - 로딩 상태 확인
   - 산책로 목록 표시 확인

2. **산책로 상세조회**
   - 산책로 카드 클릭
   - 상세 정보 로딩 확인
   - 상세 정보 표시 확인

3. **경로 시각화**
   - 상세조회 후 경로 표시 확인
   - 폴리라인 및 시작/끝 마커 확인
   - 지도 범위 자동 조정 확인

4. **뒤로가기**
   - 뒤로가기 버튼 클릭
   - 기존 경로/마커 제거 확인
   - 목록으로 복귀 확인

## 🔄 향후 개선 사항

- [ ] 페이징 처리 구현
- [ ] 실시간 위치 기반 산책로 추천

## 📝 커밋 히스토리

- `feat: 산책로 목록 조회 API 연동 및 타입 안전성 개선`
- `feat: 산책로 상세조회 API 연동 및 경로 시각화 구현`

---

**브랜치**: `feature/56-trail-api-integration`  
**관련 이슈**: #56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 산책로 목록 및 상세 정보를 백엔드 API에서 실시간으로 불러와 표시합니다.
  * 산책로 상세 정보 조회 시 경로 시각화(경로선, 시작/끝 마커 및 오버레이)가 지도에 표시됩니다.
  * 산책로 목록 로딩 상태 및 에러 메시지 표시 기능이 추가되었습니다.

* **개선 및 리팩터링**
  * 산책로 관련 지도 요소(마커, 폴리라인, 오버레이)를 일괄 관리 및 제거하는 기능이 추가되어 지도 렌더링 문제가 해결되었습니다.
  * 산책로 상세 정보 컴포넌트가 비동기 데이터 패칭 및 상태 관리로 개선되었습니다.

* **접근성**
  * 바텀시트에 시각적 변화 없이 스크린리더용 제목과 설명이 추가되어 접근성이 향상되었습니다.

* **문서**
  * 카카오맵 마커/폴리라인 제거 문제에 대한 분석 및 해결 요청 문서가 추가되었습니다.

* **타입 및 유틸리티**
  * 산책로 API 응답을 내부 타입으로 변환하는 유틸리티 함수와 타입 선언이 추가되었습니다.
  * Kakao Maps SDK의 LatLngBounds 등 타입 선언이 확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->